### PR TITLE
Add missing database indexes on reactions, attachments, sessions, and email_invites

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -94,6 +94,7 @@
         "@types/pg": "^8.16.0",
         "drizzle-kit": "^0.31.8",
         "typescript": "^5",
+        "vitest": "^4.0.18",
       },
     },
     "packages/events": {

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -11,6 +11,8 @@
     "db:generate": "dotenv -e ../../.env -- drizzle-kit generate",
     "db:push": "dotenv -e ../../.env -- drizzle-kit push",
     "db:studio": "dotenv -e ../../.env -- drizzle-kit studio",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
@@ -22,6 +24,7 @@
     "@chat/config": "workspace:*",
     "@types/pg": "^8.16.0",
     "drizzle-kit": "^0.31.8",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^4.0.18"
   }
 }

--- a/packages/db/src/schema/indexes.test.ts
+++ b/packages/db/src/schema/indexes.test.ts
@@ -1,0 +1,62 @@
+import { getTableConfig } from "drizzle-orm/pg-core";
+import { describe, expect, it } from "vitest";
+
+import { emailInvites } from "./invites";
+import { attachments, reactions } from "./messages";
+import { sessions } from "./sessions";
+
+/** Helper: return index names from a Drizzle table definition */
+function getIndexNames(table: Parameters<typeof getTableConfig>[0]): (string | undefined)[] {
+    return getTableConfig(table).indexes.map((i) => i.config.name);
+}
+
+/** Helper: return index column names for a given index */
+function getIndexColumns(table: Parameters<typeof getTableConfig>[0], indexName: string): string[] {
+    const idx = getTableConfig(table).indexes.find((i) => i.config.name === indexName);
+    if (!idx) return [];
+    return idx.config.columns
+        .map((c) => ("name" in c ? (c.name as string) : undefined))
+        .filter((name): name is string => name !== undefined);
+}
+
+describe("database indexes", () => {
+    describe("reactions table", () => {
+        it("has an index on messageId for efficient per-message lookups", () => {
+            expect(getIndexNames(reactions)).toContain("reactions_message_idx");
+        });
+
+        it("reactions_message_idx covers the message_id column", () => {
+            expect(getIndexColumns(reactions, "reactions_message_idx")).toEqual(["message_id"]);
+        });
+    });
+
+    describe("attachments table", () => {
+        it("has an index on messageId for efficient per-message lookups", () => {
+            expect(getIndexNames(attachments)).toContain("attachments_message_idx");
+        });
+
+        it("attachments_message_idx covers the message_id column", () => {
+            expect(getIndexColumns(attachments, "attachments_message_idx")).toEqual(["message_id"]);
+        });
+    });
+
+    describe("sessions table", () => {
+        it("has an index on userId for efficient session lookups by user", () => {
+            expect(getIndexNames(sessions)).toContain("sessions_user_idx");
+        });
+
+        it("sessions_user_idx covers the user_id column", () => {
+            expect(getIndexColumns(sessions, "sessions_user_idx")).toEqual(["user_id"]);
+        });
+    });
+
+    describe("emailInvites table", () => {
+        it("has an index on email for efficient invite lookups by email", () => {
+            expect(getIndexNames(emailInvites)).toContain("email_invites_email_idx");
+        });
+
+        it("email_invites_email_idx covers the email column", () => {
+            expect(getIndexColumns(emailInvites, "email_invites_email_idx")).toEqual(["email"]);
+        });
+    });
+});

--- a/packages/db/src/schema/invites.ts
+++ b/packages/db/src/schema/invites.ts
@@ -1,4 +1,13 @@
-import { boolean, integer, pgEnum, pgTable, text, timestamp, varchar } from "drizzle-orm/pg-core";
+import {
+    boolean,
+    index,
+    integer,
+    pgEnum,
+    pgTable,
+    text,
+    timestamp,
+    varchar
+} from "drizzle-orm/pg-core";
 import { nanoid } from "nanoid";
 
 import { users } from "./users";
@@ -25,19 +34,23 @@ export const inviteLinks = pgTable("invite_links", {
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow()
 });
 
-export const emailInvites = pgTable("email_invites", {
-    id: varchar("id", { length: 36 })
-        .primaryKey()
-        .$defaultFn(() => nanoid()),
-    email: varchar("email", { length: 255 }).notNull(),
-    invitedBy: varchar("invited_by", { length: 36 })
-        .notNull()
-        .references(() => users.id, { onDelete: "cascade" }),
-    token: varchar("token", { length: 64 }).notNull().unique(),
-    status: inviteStatusEnum("status").notNull().default("pending"),
-    expiresAt: timestamp("expires_at", { withTimezone: true }).notNull(),
-    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow()
-});
+export const emailInvites = pgTable(
+    "email_invites",
+    {
+        id: varchar("id", { length: 36 })
+            .primaryKey()
+            .$defaultFn(() => nanoid()),
+        email: varchar("email", { length: 255 }).notNull(),
+        invitedBy: varchar("invited_by", { length: 36 })
+            .notNull()
+            .references(() => users.id, { onDelete: "cascade" }),
+        token: varchar("token", { length: 64 }).notNull().unique(),
+        status: inviteStatusEnum("status").notNull().default("pending"),
+        expiresAt: timestamp("expires_at", { withTimezone: true }).notNull(),
+        createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow()
+    },
+    (table) => [index("email_invites_email_idx").on(table.email)]
+);
 
 export const joinRequests = pgTable("join_requests", {
     id: varchar("id", { length: 36 })

--- a/packages/db/src/schema/messages.ts
+++ b/packages/db/src/schema/messages.ts
@@ -63,25 +63,32 @@ export const reactions = pgTable(
         emoji: varchar("emoji", { length: 50 }).notNull(),
         createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow()
     },
-    (table) => [unique("reactions_unique").on(table.messageId, table.userId, table.emoji)]
+    (table) => [
+        unique("reactions_unique").on(table.messageId, table.userId, table.emoji),
+        index("reactions_message_idx").on(table.messageId)
+    ]
 );
 
-export const attachments = pgTable("attachments", {
-    id: varchar("id", { length: 36 })
-        .primaryKey()
-        .$defaultFn(() => nanoid()),
-    messageId: varchar("message_id", { length: 36 })
-        .notNull()
-        .references(() => messages.id, { onDelete: "cascade" }),
-    cloudinaryId: varchar("cloudinary_id", { length: 255 }).notNull(),
-    url: text("url").notNull(),
-    filename: varchar("filename", { length: 255 }).notNull(),
-    mimeType: varchar("mime_type", { length: 100 }),
-    size: bigint("size", { mode: "number" }),
-    width: integer("width"),
-    height: integer("height"),
-    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow()
-});
+export const attachments = pgTable(
+    "attachments",
+    {
+        id: varchar("id", { length: 36 })
+            .primaryKey()
+            .$defaultFn(() => nanoid()),
+        messageId: varchar("message_id", { length: 36 })
+            .notNull()
+            .references(() => messages.id, { onDelete: "cascade" }),
+        cloudinaryId: varchar("cloudinary_id", { length: 255 }).notNull(),
+        url: text("url").notNull(),
+        filename: varchar("filename", { length: 255 }).notNull(),
+        mimeType: varchar("mime_type", { length: 100 }),
+        size: bigint("size", { mode: "number" }),
+        width: integer("width"),
+        height: integer("height"),
+        createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow()
+    },
+    (table) => [index("attachments_message_idx").on(table.messageId)]
+);
 
 export type Message = typeof messages.$inferSelect;
 export type NewMessage = typeof messages.$inferInsert;

--- a/packages/db/src/schema/sessions.ts
+++ b/packages/db/src/schema/sessions.ts
@@ -1,22 +1,26 @@
-import { pgTable, text, timestamp, varchar } from "drizzle-orm/pg-core";
+import { index, pgTable, text, timestamp, varchar } from "drizzle-orm/pg-core";
 import { nanoid } from "nanoid";
 
 import { users } from "./users";
 
-export const sessions = pgTable("sessions", {
-    id: varchar("id", { length: 36 })
-        .primaryKey()
-        .$defaultFn(() => nanoid()),
-    userId: varchar("user_id", { length: 36 })
-        .notNull()
-        .references(() => users.id, { onDelete: "cascade" }),
-    token: text("token").notNull().unique(),
-    expiresAt: timestamp("expires_at", { withTimezone: true }).notNull(),
-    ipAddress: text("ip_address"),
-    userAgent: text("user_agent"),
-    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
-    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow()
-});
+export const sessions = pgTable(
+    "sessions",
+    {
+        id: varchar("id", { length: 36 })
+            .primaryKey()
+            .$defaultFn(() => nanoid()),
+        userId: varchar("user_id", { length: 36 })
+            .notNull()
+            .references(() => users.id, { onDelete: "cascade" }),
+        token: text("token").notNull().unique(),
+        expiresAt: timestamp("expires_at", { withTimezone: true }).notNull(),
+        ipAddress: text("ip_address"),
+        userAgent: text("user_agent"),
+        createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+        updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow()
+    },
+    (table) => [index("sessions_user_idx").on(table.userId)]
+);
 
 export type Session = typeof sessions.$inferSelect;
 export type NewSession = typeof sessions.$inferInsert;

--- a/packages/db/vitest.config.ts
+++ b/packages/db/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+    test: {
+        globals: true,
+        environment: "node",
+        include: ["src/**/*.test.ts"],
+        restoreMocks: true
+    }
+});


### PR DESCRIPTION
## Summary
- Add `reactions_message_idx` index on `reactions.messageId` for efficient per-message reaction lookups
- Add `attachments_message_idx` index on `attachments.messageId` for efficient per-message attachment lookups  
- Add `sessions_user_idx` index on `sessions.userId` for session lookups during auth flows
- Add `email_invites_email_idx` index on `emailInvites.email` for invite lookups by email address
- Add vitest to `packages/db` with 8 schema-level index tests

## Testing
Run `bun run test` from `packages/db` — 8 tests verify all indexes are present and cover the correct columns.

Closes #6