### PR TITLE
Add unique constraint on accounts(providerId, accountId) to prevent duplicate OAuth

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -94,6 +94,7 @@
         "@types/pg": "^8.16.0",
         "drizzle-kit": "^0.31.8",
         "typescript": "^5",
+        "vitest": "^4.0.18",
       },
     },
     "packages/events": {

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -11,6 +11,8 @@
     "db:generate": "dotenv -e ../../.env -- drizzle-kit generate",
     "db:push": "dotenv -e ../../.env -- drizzle-kit push",
     "db:studio": "dotenv -e ../../.env -- drizzle-kit studio",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
@@ -22,6 +24,7 @@
     "@chat/config": "workspace:*",
     "@types/pg": "^8.16.0",
     "drizzle-kit": "^0.31.8",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^4.0.18"
   }
 }

--- a/packages/db/src/schema/accounts.test.ts
+++ b/packages/db/src/schema/accounts.test.ts
@@ -1,0 +1,25 @@
+import { getTableConfig } from "drizzle-orm/pg-core";
+import { describe, expect, it } from "vitest";
+
+import { accounts } from "./accounts";
+
+describe("accounts schema", () => {
+    it("has a unique constraint on (providerId, accountId)", () => {
+        const config = getTableConfig(accounts);
+        const constraint = config.uniqueConstraints.find(
+            (uc) => uc.name === "accounts_provider_account_unique"
+        );
+
+        expect(constraint).toBeDefined();
+        expect(constraint!.columns.map((c) => c.name)).toEqual(["provider_id", "account_id"]);
+    });
+
+    it("prevents duplicate OAuth accounts from the same provider", () => {
+        // Verify the constraint exists at the schema level — the actual DB
+        // enforcement is handled by PostgreSQL, but this ensures the migration
+        // will include the constraint.
+        const config = getTableConfig(accounts);
+        const uniqueNames = config.uniqueConstraints.map((uc) => uc.name);
+        expect(uniqueNames).toContain("accounts_provider_account_unique");
+    });
+});

--- a/packages/db/src/schema/accounts.ts
+++ b/packages/db/src/schema/accounts.ts
@@ -1,27 +1,31 @@
-import { pgTable, text, timestamp, varchar } from "drizzle-orm/pg-core";
+import { pgTable, text, timestamp, unique, varchar } from "drizzle-orm/pg-core";
 import { nanoid } from "nanoid";
 
 import { users } from "./users";
 
-export const accounts = pgTable("accounts", {
-    id: varchar("id", { length: 36 })
-        .primaryKey()
-        .$defaultFn(() => nanoid()),
-    userId: varchar("user_id", { length: 36 })
-        .notNull()
-        .references(() => users.id, { onDelete: "cascade" }),
-    accountId: text("account_id").notNull(),
-    providerId: varchar("provider_id", { length: 50 }).notNull(),
-    accessToken: text("access_token"),
-    refreshToken: text("refresh_token"),
-    accessTokenExpiresAt: timestamp("access_token_expires_at", { withTimezone: true }),
-    refreshTokenExpiresAt: timestamp("refresh_token_expires_at", { withTimezone: true }),
-    scope: text("scope"),
-    idToken: text("id_token"),
-    password: text("password"),
-    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
-    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow()
-});
+export const accounts = pgTable(
+    "accounts",
+    {
+        id: varchar("id", { length: 36 })
+            .primaryKey()
+            .$defaultFn(() => nanoid()),
+        userId: varchar("user_id", { length: 36 })
+            .notNull()
+            .references(() => users.id, { onDelete: "cascade" }),
+        accountId: text("account_id").notNull(),
+        providerId: varchar("provider_id", { length: 50 }).notNull(),
+        accessToken: text("access_token"),
+        refreshToken: text("refresh_token"),
+        accessTokenExpiresAt: timestamp("access_token_expires_at", { withTimezone: true }),
+        refreshTokenExpiresAt: timestamp("refresh_token_expires_at", { withTimezone: true }),
+        scope: text("scope"),
+        idToken: text("id_token"),
+        password: text("password"),
+        createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+        updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow()
+    },
+    (table) => [unique("accounts_provider_account_unique").on(table.providerId, table.accountId)]
+);
 
 export type Account = typeof accounts.$inferSelect;
 export type NewAccount = typeof accounts.$inferInsert;

--- a/packages/db/vitest.config.ts
+++ b/packages/db/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+    test: {
+        globals: true,
+        environment: "node",
+        include: ["src/**/*.test.ts"],
+        restoreMocks: true
+    }
+});


### PR DESCRIPTION
## Summary
- Add unique constraint `accounts_provider_account_unique` on `(providerId, accountId)` to prevent duplicate OAuth account linkages
- Set up vitest for `packages/db` with schema constraint tests

## Testing
Run `bun run test` from `packages/db` — 2 tests verify the unique constraint exists and covers the correct columns.

Closes #7