### PR TITLE
Clean up Redis subscriber on server shutdown to prevent memory leaks

### DIFF
--- a/apps/socket/package.json
+++ b/apps/socket/package.json
@@ -6,6 +6,8 @@
   "scripts": {
     "dev": "dotenv -e ../../.env -- bun --watch src/index.ts",
     "start": "dotenv -e ../../.env -- bun src/index.ts",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
@@ -18,6 +20,7 @@
   "devDependencies": {
     "@chat/config": "workspace:*",
     "@types/node": "^20",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^4.0.18"
   }
 }

--- a/apps/socket/src/index.ts
+++ b/apps/socket/src/index.ts
@@ -12,6 +12,8 @@ import type {
 } from "@chat/events";
 import { subscribeToEvents } from "@chat/events/subscriber";
 
+import { gracefulShutdown } from "./shutdown";
+
 const port = parseInt(process.env.SOCKET_PORT || "3369", 10);
 const appUrl = process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3367";
 
@@ -31,10 +33,14 @@ const io = new Server<ClientToServerEvents, ServerToClientEvents, InterServerEve
 
 // Set up Redis adapter if REDIS_URL is provided
 const redisUrl = process.env.REDIS_URL;
+let pubClient: ReturnType<typeof createClient> | null = null;
+let subClient: ReturnType<typeof createClient> | null = null;
+let redisSubscriber: ReturnType<typeof subscribeToEvents> | null = null;
+
 if (redisUrl) {
     try {
-        const pubClient = createClient({ url: redisUrl });
-        const subClient = pubClient.duplicate();
+        pubClient = createClient({ url: redisUrl });
+        subClient = pubClient.duplicate();
 
         await Promise.all([pubClient.connect(), subClient.connect()]);
 
@@ -42,12 +48,21 @@ if (redisUrl) {
         console.log("Socket.io Redis adapter connected");
 
         // Subscribe to Redis pub/sub events from API routes
-        subscribeToEvents(io, redisUrl);
+        redisSubscriber = subscribeToEvents(io, redisUrl);
         console.log("Subscribed to Redis pub/sub events");
     } catch (error) {
         console.error("Failed to connect Redis adapter:", error);
     }
 }
+
+// Graceful shutdown handler
+async function shutdown() {
+    await gracefulShutdown({ redisSubscriber, pubClient, subClient, io, server });
+    process.exit(0);
+}
+
+process.on("SIGTERM", shutdown);
+process.on("SIGINT", shutdown);
 
 // Parse cookies from a cookie header string
 function parseCookies(cookieHeader: string): Record<string, string> {

--- a/apps/socket/src/shutdown.test.ts
+++ b/apps/socket/src/shutdown.test.ts
@@ -1,0 +1,107 @@
+import type { Server as HttpServer } from "http";
+import type { Server as IoServer } from "socket.io";
+import { describe, expect, it, vi } from "vitest";
+
+import { gracefulShutdown } from "./shutdown";
+
+function createMockQuittable() {
+    return { quit: vi.fn().mockResolvedValue("OK") };
+}
+
+function createMockIo() {
+    return { close: vi.fn() } as unknown as IoServer;
+}
+
+function createMockServer() {
+    return { close: vi.fn() } as unknown as HttpServer;
+}
+
+describe("gracefulShutdown", () => {
+    it("quits the Redis subscriber", async () => {
+        const redisSubscriber = createMockQuittable();
+        await gracefulShutdown({
+            redisSubscriber,
+            pubClient: createMockQuittable(),
+            subClient: createMockQuittable(),
+            io: createMockIo(),
+            server: createMockServer()
+        });
+        expect(redisSubscriber.quit).toHaveBeenCalledTimes(1);
+    });
+
+    it("quits the pub and sub Redis clients", async () => {
+        const pubClient = createMockQuittable();
+        const subClient = createMockQuittable();
+        await gracefulShutdown({
+            redisSubscriber: createMockQuittable(),
+            pubClient,
+            subClient,
+            io: createMockIo(),
+            server: createMockServer()
+        });
+        expect(pubClient.quit).toHaveBeenCalledTimes(1);
+        expect(subClient.quit).toHaveBeenCalledTimes(1);
+    });
+
+    it("closes the Socket.io server", async () => {
+        const io = createMockIo();
+        await gracefulShutdown({
+            redisSubscriber: createMockQuittable(),
+            pubClient: createMockQuittable(),
+            subClient: createMockQuittable(),
+            io,
+            server: createMockServer()
+        });
+        expect(io.close).toHaveBeenCalledTimes(1);
+    });
+
+    it("closes the HTTP server", async () => {
+        const server = createMockServer();
+        await gracefulShutdown({
+            redisSubscriber: createMockQuittable(),
+            pubClient: createMockQuittable(),
+            subClient: createMockQuittable(),
+            io: createMockIo(),
+            server
+        });
+        expect(server.close).toHaveBeenCalledTimes(1);
+    });
+
+    it("handles null redisSubscriber gracefully", async () => {
+        await expect(
+            gracefulShutdown({
+                redisSubscriber: null,
+                pubClient: createMockQuittable(),
+                subClient: createMockQuittable(),
+                io: createMockIo(),
+                server: createMockServer()
+            })
+        ).resolves.not.toThrow();
+    });
+
+    it("handles null pubClient and subClient gracefully", async () => {
+        await expect(
+            gracefulShutdown({
+                redisSubscriber: createMockQuittable(),
+                pubClient: null,
+                subClient: null,
+                io: createMockIo(),
+                server: createMockServer()
+            })
+        ).resolves.not.toThrow();
+    });
+
+    it("handles all null Redis connections (no Redis configured)", async () => {
+        const io = createMockIo();
+        const server = createMockServer();
+        await gracefulShutdown({
+            redisSubscriber: null,
+            pubClient: null,
+            subClient: null,
+            io,
+            server
+        });
+        expect(io.close).toHaveBeenCalledTimes(1);
+        expect(server.close).toHaveBeenCalledTimes(1);
+    });
+});

--- a/apps/socket/src/shutdown.ts
+++ b/apps/socket/src/shutdown.ts
@@ -1,0 +1,35 @@
+import type { Server as HttpServer } from "http";
+import type { Server as IoServer } from "socket.io";
+
+interface Quittable {
+    quit: () => Promise<unknown>;
+}
+
+interface ShutdownDeps {
+    redisSubscriber: Quittable | null;
+    pubClient: Quittable | null;
+    subClient: Quittable | null;
+    io: IoServer;
+    server: HttpServer;
+}
+
+/**
+ * Gracefully shut down all connections.
+ * Exported for testability; called by SIGTERM/SIGINT handlers.
+ */
+export async function gracefulShutdown(deps: ShutdownDeps) {
+    console.log("Shutting down...");
+
+    if (deps.redisSubscriber) {
+        await deps.redisSubscriber.quit();
+    }
+    if (deps.pubClient) {
+        await deps.pubClient.quit();
+    }
+    if (deps.subClient) {
+        await deps.subClient.quit();
+    }
+
+    deps.io.close();
+    deps.server.close();
+}

--- a/apps/socket/vitest.config.ts
+++ b/apps/socket/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+    test: {
+        globals: true,
+        environment: "node",
+        include: ["src/**/*.test.ts"],
+        restoreMocks: true
+    }
+});

--- a/bun.lock
+++ b/bun.lock
@@ -28,6 +28,7 @@
         "@chat/config": "workspace:*",
         "@types/node": "^20",
         "typescript": "^5",
+        "vitest": "^4.0.18",
       },
     },
     "apps/web": {


### PR DESCRIPTION
## Summary
- Store the Redis subscriber returned by `subscribeToEvents()` instead of discarding it
- Add `SIGTERM`/`SIGINT` handlers for graceful shutdown that quit all Redis connections
- Extract shutdown logic into a testable `gracefulShutdown()` function in `apps/socket/src/shutdown.ts`
- Set up vitest for `apps/socket` with 7 shutdown tests

## Testing
Run `bun run test` from `apps/socket` — 7 tests verify:
- Redis subscriber, pub client, and sub client are all quit on shutdown
- Socket.io and HTTP servers are closed
- Graceful handling when Redis connections are null (no Redis configured)

Closes #12