### PR TITLE
Configure database connection pool limits and SSL

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -94,6 +94,7 @@
         "@types/pg": "^8.16.0",
         "drizzle-kit": "^0.31.8",
         "typescript": "^5",
+        "vitest": "^4.0.18",
       },
     },
     "packages/events": {

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -11,6 +11,8 @@
     "db:generate": "dotenv -e ../../.env -- drizzle-kit generate",
     "db:push": "dotenv -e ../../.env -- drizzle-kit push",
     "db:studio": "dotenv -e ../../.env -- drizzle-kit studio",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
@@ -22,6 +24,7 @@
     "@chat/config": "workspace:*",
     "@types/pg": "^8.16.0",
     "drizzle-kit": "^0.31.8",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^4.0.18"
   }
 }

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,11 +1,26 @@
 import { drizzle } from "drizzle-orm/node-postgres";
+import type { PoolConfig } from "pg";
 import { Pool } from "pg";
 
 import * as schema from "./schema";
 
-const pool = new Pool({
-    connectionString: process.env.DATABASE_URL
-});
+/**
+ * Build a pg PoolConfig from environment variables.
+ * Exported for testability.
+ */
+export function buildPoolConfig(): PoolConfig {
+    return {
+        connectionString: process.env.DATABASE_URL,
+        max: parseInt(process.env.DB_POOL_MAX || "20", 10),
+        idleTimeoutMillis: 30_000,
+        connectionTimeoutMillis: 5_000,
+        ...(process.env.NODE_ENV === "production" && {
+            ssl: { rejectUnauthorized: false }
+        })
+    };
+}
+
+const pool = new Pool(buildPoolConfig());
 
 export const db = drizzle(pool, { schema });
 

--- a/packages/db/src/pool-config.test.ts
+++ b/packages/db/src/pool-config.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Re-import a fresh module each test to pick up env changes
+async function importFresh() {
+    return await import("./index.js");
+}
+
+describe("buildPoolConfig", () => {
+    const originalEnv = { ...process.env };
+
+    beforeEach(() => {
+        vi.resetModules();
+    });
+
+    afterEach(() => {
+        process.env = { ...originalEnv };
+    });
+
+    it("uses default max of 20 when DB_POOL_MAX is not set", async () => {
+        delete process.env.DB_POOL_MAX;
+        const { buildPoolConfig } = await importFresh();
+        const config = buildPoolConfig();
+        expect(config.max).toBe(20);
+    });
+
+    it("respects DB_POOL_MAX environment variable", async () => {
+        process.env.DB_POOL_MAX = "50";
+        const { buildPoolConfig } = await importFresh();
+        const config = buildPoolConfig();
+        expect(config.max).toBe(50);
+    });
+
+    it("sets idleTimeoutMillis to 30 seconds", async () => {
+        const { buildPoolConfig } = await importFresh();
+        const config = buildPoolConfig();
+        expect(config.idleTimeoutMillis).toBe(30_000);
+    });
+
+    it("sets connectionTimeoutMillis to 5 seconds", async () => {
+        const { buildPoolConfig } = await importFresh();
+        const config = buildPoolConfig();
+        expect(config.connectionTimeoutMillis).toBe(5_000);
+    });
+
+    it("does not include ssl in non-production", async () => {
+        process.env.NODE_ENV = "development";
+        const { buildPoolConfig } = await importFresh();
+        const config = buildPoolConfig();
+        expect(config.ssl).toBeUndefined();
+    });
+
+    it("includes ssl config in production", async () => {
+        process.env.NODE_ENV = "production";
+        const { buildPoolConfig } = await importFresh();
+        const config = buildPoolConfig();
+        expect(config.ssl).toEqual({ rejectUnauthorized: false });
+    });
+
+    it("passes through DATABASE_URL as connectionString", async () => {
+        process.env.DATABASE_URL = "postgresql://user:pass@host:5432/db";
+        const { buildPoolConfig } = await importFresh();
+        const config = buildPoolConfig();
+        expect(config.connectionString).toBe("postgresql://user:pass@host:5432/db");
+    });
+});

--- a/packages/db/vitest.config.ts
+++ b/packages/db/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+    test: {
+        globals: true,
+        environment: "node",
+        include: ["src/**/*.test.ts"],
+        restoreMocks: true
+    }
+});


### PR DESCRIPTION
## Summary
- Configure pg Pool with max connections (default 20, configurable via `DB_POOL_MAX` env var)
- Add idle timeout (30s) and connection timeout (5s) to prevent connection exhaustion
- Enable SSL with `rejectUnauthorized: false` in production environments
- Extract `buildPoolConfig()` for testability

## Testing
Run `bun run test` from `packages/db` — 7 tests verify:
- Default max of 20 connections
- Custom DB_POOL_MAX is respected
- Idle and connection timeouts are set correctly
- SSL is absent in development, present in production
- DATABASE_URL is passed through

Closes #13