### PR TITLE
Add security headers to production Caddy configuration

### DIFF
--- a/caddy/Caddyfile.prod
+++ b/caddy/Caddyfile.prod
@@ -1,4 +1,13 @@
 yourdomain.com {
+	header {
+		Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
+		X-Content-Type-Options "nosniff"
+		X-Frame-Options "DENY"
+		Referrer-Policy "strict-origin-when-cross-origin"
+		Permissions-Policy "geolocation=(), microphone=(), camera=()"
+		-Server
+	}
+
 	@socketio path /socket.io/*
 	reverse_proxy @socketio localhost:3369
 	reverse_proxy localhost:3368


### PR DESCRIPTION
## Summary
- Adds security headers to `caddy/Caddyfile.prod` to protect against common browser-based attacks
- Removes the `Server` header to prevent fingerprinting

## Headers Added
- `Strict-Transport-Security` — HSTS with 1 year max-age, includeSubDomains, and preload
- `X-Content-Type-Options: nosniff` — Prevents MIME-type sniffing
- `X-Frame-Options: DENY` — Prevents clickjacking
- `Referrer-Policy: strict-origin-when-cross-origin` — Limits referrer leakage
- `Permissions-Policy` — Disables geolocation, microphone, and camera APIs

Closes #15