### PR TITLE
Bind Docker database and Redis ports to localhost only

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-chat_password}
       POSTGRES_DB: ${POSTGRES_DB:-chat}
     ports:
-      - "5432:5432"
+      - "127.0.0.1:5432:5432"
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-chat}"]
       interval: 10s
@@ -21,7 +21,7 @@ services:
     restart: unless-stopped
     command: redis-server --appendonly yes
     ports:
-      - "6379:6379"
+      - "127.0.0.1:6379:6379"
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
       interval: 10s


### PR DESCRIPTION
## Summary
- Binds PostgreSQL and Redis port mappings to `127.0.0.1` to prevent exposure on all network interfaces
- Prevents accidental internet-facing database/cache access in environments with poor firewall rules

## Changes
- `docker-compose.yml`: `"5432:5432"` -> `"127.0.0.1:5432:5432"`
- `docker-compose.yml`: `"6379:6379"` -> `"127.0.0.1:6379:6379"`

Closes #16