### PR TITLE
Remove contentHtml from API responses and event payloads to prevent XSS

### DIFF
--- a/apps/web/src/app/api/channels/[id]/messages/route.ts
+++ b/apps/web/src/app/api/channels/[id]/messages/route.ts
@@ -208,7 +208,6 @@ export async function POST(request: Request, { params }: RouteParams) {
         const messagePayload: MessagePayload = {
             id: newMessage.id,
             content: newMessage.content,
-            contentHtml: newMessage.contentHtml,
             channelId: newMessage.channelId,
             conversationId: newMessage.conversationId,
             authorId: newMessage.authorId,

--- a/apps/web/src/app/api/dm/[id]/messages/route.ts
+++ b/apps/web/src/app/api/dm/[id]/messages/route.ts
@@ -169,7 +169,6 @@ export async function POST(request: Request, { params }: RouteParams) {
         const messagePayload: MessagePayload = {
             id: newMessage.id,
             content: newMessage.content,
-            contentHtml: newMessage.contentHtml,
             channelId: newMessage.channelId,
             conversationId: newMessage.conversationId,
             authorId: newMessage.authorId,

--- a/apps/web/src/app/api/messages/[id]/route.ts
+++ b/apps/web/src/app/api/messages/[id]/route.ts
@@ -117,7 +117,6 @@ export async function PATCH(request: Request, { params }: RouteParams) {
         const payload = {
             id: updatedMessage.id,
             content: updatedMessage.content,
-            contentHtml: updatedMessage.contentHtml,
             channelId: updatedMessage.channelId,
             conversationId: updatedMessage.conversationId,
             authorId: updatedMessage.authorId,

--- a/packages/events/src/socket-events.ts
+++ b/packages/events/src/socket-events.ts
@@ -84,7 +84,6 @@ export interface SocketData {
 export interface MessagePayload {
     id: string;
     content: string;
-    contentHtml?: string | null;
     channelId?: string | null;
     conversationId?: string | null;
     authorId: string;


### PR DESCRIPTION
## Summary
- Removes the unused `contentHtml` field from the `MessagePayload` TypeScript interface
- Strips `contentHtml` from all API response payloads (channel messages, DM messages, message edit)
- The DB column is preserved (no migration needed) but is no longer exposed to clients

## Why
The `contentHtml` field was stored but never rendered or sanitized. If future code were to render it with `dangerouslySetInnerHTML`, it would be a stored XSS vector. Removing it from the API surface eliminates this risk entirely.

## Files Changed
- `packages/events/src/socket-events.ts` — Remove `contentHtml` from `MessagePayload`
- `apps/web/src/app/api/channels/[id]/messages/route.ts` — Remove from POST response
- `apps/web/src/app/api/dm/[id]/messages/route.ts` — Remove from POST response
- `apps/web/src/app/api/messages/[id]/route.ts` — Remove from PATCH response

Closes #20