### PR TITLE
Add loading.tsx files for route transitions

### DIFF
--- a/apps/web/src/app/(app)/channels/[id]/loading.tsx
+++ b/apps/web/src/app/(app)/channels/[id]/loading.tsx
@@ -1,0 +1,39 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function ChannelLoading() {
+    return (
+        <div className="flex flex-1 flex-col">
+            {/* Channel header skeleton */}
+            <div className="flex h-14 items-center gap-3 border-b px-4">
+                <Skeleton className="h-5 w-5 rounded" />
+                <Skeleton className="h-5 w-32" />
+                <div className="flex-1" />
+                <Skeleton className="h-8 w-8 rounded" />
+            </div>
+
+            {/* Messages skeleton */}
+            <div className="flex-1 space-y-4 p-4">
+                {Array.from({ length: 5 }).map((_, i) => (
+                    <div key={i} className="flex gap-3">
+                        <Skeleton className="h-10 w-10 shrink-0 rounded-full" />
+                        <div className="space-y-2">
+                            <div className="flex items-center gap-2">
+                                <Skeleton className="h-4 w-24" />
+                                <Skeleton className="h-3 w-16" />
+                            </div>
+                            <Skeleton
+                                className="h-4"
+                                style={{ width: `${Math.max(120, 300 - i * 40)}px` }}
+                            />
+                        </div>
+                    </div>
+                ))}
+            </div>
+
+            {/* Message input skeleton */}
+            <div className="border-t px-4 py-3">
+                <Skeleton className="h-10 w-full rounded-lg" />
+            </div>
+        </div>
+    );
+}

--- a/apps/web/src/app/(app)/dm/[id]/loading.tsx
+++ b/apps/web/src/app/(app)/dm/[id]/loading.tsx
@@ -1,0 +1,37 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function DMLoading() {
+    return (
+        <div className="flex flex-1 flex-col">
+            {/* DM header skeleton */}
+            <div className="flex h-14 items-center gap-3 border-b px-4">
+                <Skeleton className="h-8 w-8 rounded-full" />
+                <Skeleton className="h-5 w-28" />
+            </div>
+
+            {/* Messages skeleton */}
+            <div className="flex-1 space-y-4 p-4">
+                {Array.from({ length: 5 }).map((_, i) => (
+                    <div key={i} className="flex gap-3">
+                        <Skeleton className="h-10 w-10 shrink-0 rounded-full" />
+                        <div className="space-y-2">
+                            <div className="flex items-center gap-2">
+                                <Skeleton className="h-4 w-20" />
+                                <Skeleton className="h-3 w-16" />
+                            </div>
+                            <Skeleton
+                                className="h-4"
+                                style={{ width: `${Math.max(100, 280 - i * 35)}px` }}
+                            />
+                        </div>
+                    </div>
+                ))}
+            </div>
+
+            {/* Message input skeleton */}
+            <div className="border-t px-4 py-3">
+                <Skeleton className="h-10 w-full rounded-lg" />
+            </div>
+        </div>
+    );
+}

--- a/apps/web/src/app/(app)/loading.tsx
+++ b/apps/web/src/app/(app)/loading.tsx
@@ -1,0 +1,34 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function Loading() {
+    return (
+        <div className="flex flex-1 flex-col">
+            {/* Header skeleton */}
+            <div className="flex h-14 items-center gap-3 border-b px-4">
+                <Skeleton className="h-5 w-5 rounded" />
+                <Skeleton className="h-5 w-32" />
+            </div>
+
+            {/* Messages skeleton */}
+            <div className="flex-1 space-y-4 p-4">
+                {Array.from({ length: 6 }).map((_, i) => (
+                    <div key={i} className="flex gap-3">
+                        <Skeleton className="h-10 w-10 shrink-0 rounded-full" />
+                        <div className="space-y-2">
+                            <div className="flex items-center gap-2">
+                                <Skeleton className="h-4 w-24" />
+                                <Skeleton className="h-3 w-16" />
+                            </div>
+                            <Skeleton className="h-4 w-64" />
+                        </div>
+                    </div>
+                ))}
+            </div>
+
+            {/* Message input skeleton */}
+            <div className="border-t px-4 py-3">
+                <Skeleton className="h-10 w-full rounded-lg" />
+            </div>
+        </div>
+    );
+}


### PR DESCRIPTION
## Summary
- Adds skeleton loading states for the main app layout, channel pages, and DM pages
- Prevents layout shift and provides visual feedback during route transitions
- Uses existing `Skeleton` component from shadcn/ui

## Files Created
- `apps/web/src/app/(app)/loading.tsx` — Generic app loading skeleton
- `apps/web/src/app/(app)/channels/[id]/loading.tsx` — Channel page skeleton with header, messages, and input
- `apps/web/src/app/(app)/dm/[id]/loading.tsx` — DM page skeleton with header, messages, and input

Closes #22