### PR TITLE
Wire up toast notifications for user-facing errors

### DIFF
--- a/apps/web/src/app/(app)/admin/channels/page.tsx
+++ b/apps/web/src/app/(app)/admin/channels/page.tsx
@@ -2,6 +2,7 @@
 
 import { Archive, Hash, Lock, MoreHorizontal } from "lucide-react";
 import { useEffect, useState } from "react";
+import { toast } from "sonner";
 
 import { CreateChannelModal } from "@/components/channel/create-channel-modal";
 import { Badge } from "@/components/ui/badge";
@@ -45,6 +46,7 @@ export default function ChannelsPage() {
                 }
             } catch (err) {
                 console.error("Error fetching channels:", err);
+                toast.error("Failed to load channels");
             } finally {
                 setIsLoading(false);
             }
@@ -70,6 +72,7 @@ export default function ChannelsPage() {
             }
         } catch (err) {
             console.error("Error archiving channel:", err);
+            toast.error("Failed to archive channel");
         }
     };
 

--- a/apps/web/src/app/(app)/admin/invites/page.tsx
+++ b/apps/web/src/app/(app)/admin/invites/page.tsx
@@ -2,6 +2,7 @@
 
 import { Check, Copy, LinkIcon, Mail, Trash, X } from "lucide-react";
 import { useEffect, useState } from "react";
+import { toast } from "sonner";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -73,6 +74,7 @@ export default function InvitesPage() {
                 }
             } catch (err) {
                 console.error("Error fetching invites:", err);
+                toast.error("Failed to load invites");
             } finally {
                 setIsLoading(false);
             }
@@ -111,6 +113,7 @@ export default function InvitesPage() {
             }
         } catch (err) {
             console.error("Error creating link:", err);
+            toast.error("Failed to create invite link");
         } finally {
             setIsCreating(false);
         }
@@ -127,6 +130,7 @@ export default function InvitesPage() {
             }
         } catch (err) {
             console.error("Error deleting link:", err);
+            toast.error("Failed to delete invite link");
         }
     };
 
@@ -149,6 +153,7 @@ export default function InvitesPage() {
             }
         } catch (err) {
             console.error("Error handling request:", err);
+            toast.error("Failed to update access request");
         }
     };
 
@@ -171,6 +176,7 @@ export default function InvitesPage() {
             }
         } catch (err) {
             console.error("Error sending email invite:", err);
+            toast.error("Failed to send email invitation");
         } finally {
             setIsSendingEmail(false);
         }

--- a/apps/web/src/app/(app)/admin/members/page.tsx
+++ b/apps/web/src/app/(app)/admin/members/page.tsx
@@ -3,6 +3,7 @@
 import { MoreHorizontal, Shield, ShieldAlert, User } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
+import { toast } from "sonner";
 
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
@@ -52,6 +53,7 @@ export default function MembersPage() {
                 }
             } catch (err) {
                 console.error("Error fetching members:", err);
+                toast.error("Failed to load members");
             } finally {
                 setIsLoading(false);
             }
@@ -77,6 +79,7 @@ export default function MembersPage() {
             }
         } catch (err) {
             console.error("Error changing role:", err);
+            toast.error("Failed to change member role");
         }
     };
 
@@ -93,6 +96,7 @@ export default function MembersPage() {
             }
         } catch (err) {
             console.error("Error removing member:", err);
+            toast.error("Failed to remove member");
         }
     };
 

--- a/apps/web/src/app/(app)/channels/[id]/page.tsx
+++ b/apps/web/src/app/(app)/channels/[id]/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { use, useCallback, useEffect, useState } from "react";
+import { toast } from "sonner";
 
 import { MessageInput, MessageList, TypingIndicator } from "@/components/chat";
 import { Header, MemberList } from "@/components/layout";
@@ -65,6 +66,7 @@ export default function ChannelPage({ params }: ChannelPageProps) {
                 }
             } catch (err) {
                 console.error("Error fetching channel:", err);
+                toast.error("Failed to load channel");
             } finally {
                 setIsLoading(false);
             }
@@ -100,29 +102,45 @@ export default function ChannelPage({ params }: ChannelPageProps) {
 
     const handleSend = useCallback(
         async (content: string) => {
-            stopTyping();
-            await sendMessage(content);
+            try {
+                stopTyping();
+                await sendMessage(content);
+            } catch {
+                toast.error("Failed to send message");
+            }
         },
         [sendMessage, stopTyping]
     );
 
     const handleEdit = useCallback(
         async (messageId: string, content: string) => {
-            await editMessage(messageId, content);
+            try {
+                await editMessage(messageId, content);
+            } catch {
+                toast.error("Failed to edit message");
+            }
         },
         [editMessage]
     );
 
     const handleDelete = useCallback(
         async (messageId: string) => {
-            await deleteMessage(messageId);
+            try {
+                await deleteMessage(messageId);
+            } catch {
+                toast.error("Failed to delete message");
+            }
         },
         [deleteMessage]
     );
 
     const handleReact = useCallback(
         async (messageId: string, emoji: string) => {
-            await toggleReaction(messageId, emoji);
+            try {
+                await toggleReaction(messageId, emoji);
+            } catch {
+                toast.error("Failed to toggle reaction");
+            }
         },
         [toggleReaction]
     );

--- a/apps/web/src/app/(app)/dm/[id]/page.tsx
+++ b/apps/web/src/app/(app)/dm/[id]/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { use, useCallback, useEffect, useState } from "react";
+import { toast } from "sonner";
 
 import { MessageInput, MessageList, TypingIndicator } from "@/components/chat";
 import { Header } from "@/components/layout";
@@ -53,6 +54,7 @@ export default function DMPage({ params }: DMPageProps) {
                 }
             } catch (err) {
                 console.error("Error fetching conversation:", err);
+                toast.error("Failed to load conversation");
             } finally {
                 setIsLoading(false);
             }
@@ -71,29 +73,45 @@ export default function DMPage({ params }: DMPageProps) {
 
     const handleSend = useCallback(
         async (content: string) => {
-            stopTyping();
-            await sendMessage(content);
+            try {
+                stopTyping();
+                await sendMessage(content);
+            } catch {
+                toast.error("Failed to send message");
+            }
         },
         [sendMessage, stopTyping]
     );
 
     const handleEdit = useCallback(
         async (messageId: string, content: string) => {
-            await editMessage(messageId, content);
+            try {
+                await editMessage(messageId, content);
+            } catch {
+                toast.error("Failed to edit message");
+            }
         },
         [editMessage]
     );
 
     const handleDelete = useCallback(
         async (messageId: string) => {
-            await deleteMessage(messageId);
+            try {
+                await deleteMessage(messageId);
+            } catch {
+                toast.error("Failed to delete message");
+            }
         },
         [deleteMessage]
     );
 
     const handleReact = useCallback(
         async (messageId: string, emoji: string) => {
-            await toggleReaction(messageId, emoji);
+            try {
+                await toggleReaction(messageId, emoji);
+            } catch {
+                toast.error("Failed to toggle reaction");
+            }
         },
         [toggleReaction]
     );

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -4,6 +4,7 @@ import type { Metadata } from "next";
 import { DM_Sans, Geist, Geist_Mono } from "next/font/google";
 
 import { Providers } from "@/components/providers";
+import { Toaster } from "@/components/ui/sonner";
 
 const dmSans = DM_Sans({ subsets: ["latin"], variable: "--font-sans" });
 
@@ -31,6 +32,7 @@ export default function RootLayout({
         <html lang="en" className={dmSans.variable} suppressHydrationWarning>
             <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
                 <Providers>{children}</Providers>
+                <Toaster />
             </body>
         </html>
     );

--- a/apps/web/src/components/providers/preferences-provider.tsx
+++ b/apps/web/src/components/providers/preferences-provider.tsx
@@ -2,6 +2,7 @@
 
 import { useTheme } from "next-themes";
 import { createContext, type ReactNode, useCallback, useEffect, useRef, useState } from "react";
+import { toast } from "sonner";
 
 import type { DateFormat, TimeFormat } from "@/lib/format-date";
 
@@ -63,6 +64,7 @@ export function PreferencesProvider({ children }: { children: ReactNode }) {
                 }
             } catch (error) {
                 console.error("Failed to fetch preferences:", error);
+                toast.error("Failed to load preferences");
             } finally {
                 setIsLoading(false);
             }
@@ -100,6 +102,7 @@ export function PreferencesProvider({ children }: { children: ReactNode }) {
                 });
             } catch (error) {
                 console.error("Failed to save preferences:", error);
+                toast.error("Failed to save preferences");
             }
         },
         [preferences, setTheme, applyPrimaryColor]


### PR DESCRIPTION
## Summary

- Mount the Sonner `<Toaster />` component in the root layout so toast notifications are available app-wide
- Add `toast.error()` calls alongside existing `console.error` in all user-facing error catch blocks across:
  - **Channel page** (`channels/[id]/page.tsx`) — load, send, edit, delete, react errors
  - **DM page** (`dm/[id]/page.tsx`) — load, send, edit, delete, react errors
  - **Admin Members** (`admin/members/page.tsx`) — load, role change, remove errors
  - **Admin Invites** (`admin/invites/page.tsx`) — load, create link, delete link, handle request, send email errors
  - **Admin Channels** (`admin/channels/page.tsx`) — load, archive errors
  - **Preferences Provider** (`preferences-provider.tsx`) — load and save preference errors

Closes #23